### PR TITLE
Workaround for unlucky interaction between inaccurate sin() function and gcc.

### DIFF
--- a/src/lightextinction_advanced.cpp
+++ b/src/lightextinction_advanced.cpp
@@ -109,6 +109,7 @@ double G_function1(double leafAngle, double solarElevation) {
   } else {
     double a = sin(solarElevation)*cos(leafAngle)*asin(tan(solarElevation)/tan(leafAngle));
     double b = sqrt(pow(sin(leafAngle), 2.0) - pow(sin(solarElevation), 2.0));
+    if (isnan(b)) b = 0;
     G = (2.0/M_PI)*(a + b);
   }
   return(G);


### PR DESCRIPTION
Unfortunately the package doesn't pass its tests with mingw-w64 v12 on Windows. Rtools45 still uses mingw-w64 v11, to allow some time for updating packages that fail with v12.

The symptom is exceptions `c++ error: NA Idf`. It turns out this is because the `sin()` function in mingw-w64 v12 is slightly less accurate than in v11 (v12 decided to use the function from UCRT, the Windows C runtime). The differences, however, are small and always within 1 ULP for values used in the failing tests.

I've narrowed this down to that the value computed, while "reasonably precise", is still different from the correct value. In G_function1(), the argument of `sqrt()` consequently becomes negative - a very small absolute value, but, negative, so the result is NaN. This happens by GCC constant folding the value of `sin(leafAngle)`, but the value of `sin(solarElevation)` is computed at runtime. Even when `leafAngle` is exactly equal to `solarElevation`, the argument of `sqrt()` is consequently negative, and this is what happens in the tests.

The attached hack/work-around makes the package pass on my system with v12. I don't understand the math behind - maybe you might prefer a more elegant solution, perhaps handling some error inputs of the function, and I can test that for you with v12, but in principle, it is probably a good idea to be able to recover from a NaN, rather than (only) trying to rule out one might get it.

Intuitively one could say this is a compiler bug (or mingw-w64 bug) and I've reported this as https://github.com/mingw-w64/mingw-w64/issues/89, but it is something that might be difficult to get fixed due to conflicting interests between accuracy and performance. So I would recommend working that around.

